### PR TITLE
Fixed Pokemon deployed_fort_id (field8) wire type

### DIFF
--- a/src/POGOProtos/Data/PokemonData.php
+++ b/src/POGOProtos/Data/PokemonData.php
@@ -123,11 +123,13 @@ namespace POGOProtos\Data {
 
             break;
           case 8: // optional string deployed_fort_id = 8
-            if($wire !== 0) {
-              throw new \Exception("Incorrect wire format for field $field, expected: 0 got: $wire");
+            if($wire !== 2) {
+              throw new \Exception("Incorrect wire format for field $field, expected: 2 got: $wire");
             }
-            $tmp = Protobuf::read_varint($fp, $limit);
-            if ($tmp === false) throw new \Exception('Protobuf::read_varint returned false');
+            $len = Protobuf::read_varint($fp, $limit);
+            if ($len === false) throw new \Exception('Protobuf::read_varint returned false');
+            $tmp = Protobuf::read_bytes($fp, $len, $limit);
+            if ($tmp === false) throw new \Exception("read_bytes($len) returned false");
             $this->deployedFortId = $tmp;
 
             break;


### PR DESCRIPTION
As it even says in the comment, `deployed_fort_id` (field _8_) is a string. So the wire type should be `2` (_Length-delimited_).

This adjusts the wire format check ([mentioned in #142](https://github.com/NicklasWallgren/PokemonGoAPI-PHP/issues/142#issuecomment-251708414)) aswell as the actual reading. I did not encounter the [_follow-up error_](https://github.com/NicklasWallgren/PokemonGoAPI-PHP/issues/142#issuecomment-251800252) @voxx describes when decoding [pogodumpU8IH4U.txt](https://github.com/NicklasWallgren/PokemonGoAPI-PHP/issues/142#issuecomment-251824141). I think this is because he only changed the wire format check, not the reading (I did not mention / think of it at the time of writing the proposal).

Do you have any idea why this was wrong @NicklasWallgren? All other string fields seem to have been generated correctly.
