### PR TITLE
Switched to classmap autoloader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,15 +10,9 @@
         "php": ">=5.6"
     },
     "autoload": {
-      "psr-4": {
-        "POGOProtos\\": "src/POGOProtos/"
-      },
+      "classmap": ["src/"],
       "files": [
-        "src/protocolbuffers.inc.php",
-        "src/POGOProtos/Networking/Envelopes/RequestEnvelope.php",
-        "src/POGOProtos/Networking/Envelopes/ResponseEnvelope.php",
-        "src/POGOProtos/Networking/Responses/EvolvePokemonResponse.php",
-        "src/POGOProtos/Networking/Responses/UpgradePokemonResponse.php"
+        "src/protocolbuffers.inc.php"
       ]
     }
 }


### PR DESCRIPTION
By using the [classmap autoloader](https://getcomposer.org/doc/04-schema.md#classmap) the naming-convention-violation-problem in https://github.com/NicklasWallgren/pogoprotos-php/issues/10 becomes obsolete.

Also, there is no longer a need to manually include files containing multiple classes in the `files` section.
